### PR TITLE
Use latest Python 3 and pip

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -17,7 +17,7 @@ if (Sys.info()[['user']] == 'shiny'){
 } else if (Sys.info()[['user']] == 'rstudio-connect'){
   
   # Running on remote server
-  Sys.setenv(PYTHON_PATH = '/opt/python/3.7.6/bin/python')
+  Sys.setenv(PYTHON_PATH = '/opt/python/3.7.7/bin/python3')
   Sys.setenv(VIRTUALENV_NAME = paste0(VIRTUALENV_NAME, '/')) # include '/' => installs into rstudio-connect/apps/
   Sys.setenv(RETICULATE_PYTHON = paste0(VIRTUALENV_NAME, '/bin/python'))
   

--- a/server.R
+++ b/server.R
@@ -4,7 +4,7 @@ library(DT)
 library(RColorBrewer)
 
 # Define any Python packages needed for the app here:
-PYTHON_DEPENDENCIES = c('numpy', 'pip')
+PYTHON_DEPENDENCIES = c('pip', 'numpy')
 
 # Begin app server
 shinyServer(function(input, output) {

--- a/server.R
+++ b/server.R
@@ -4,7 +4,7 @@ library(DT)
 library(RColorBrewer)
 
 # Define any Python packages needed for the app here:
-PYTHON_DEPENDENCIES = c('numpy')
+PYTHON_DEPENDENCIES = c('numpy', 'pip')
 
 # Begin app server
 shinyServer(function(input, output) {


### PR DESCRIPTION
The app suddenly produced an error and was failing to install packages. I think this might have been due to ShinyApps upgrading to a new pip or Python version but not sure.

```
# logs.txt from shinyapps.io

Creating virtual environment 'example_env_name' ...
Using python: python3
Already using interpreter /usr/bin/python3
Using base prefix '/usr'
New python executable in /home/shiny/.virtualenvs/example_env_name/bin/python3
Also creating executable in /home/shiny/.virtualenvs/example_env_name/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
Traceback (most recent call last):
     File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
          "__main__", mod_spec)
     File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
          exec(code, run_globals)
     File "/home/shiny/.virtualenvs/example_env_name/lib/python3.5/site-packages/pip/__main__.py", line 21, in <module>
          from pip._internal.cli.main import main as _main
     File "/home/shiny/.virtualenvs/example_env_name/lib/python3.5/site-packages/pip/_internal/cli/main.py", line 60
          sys.stderr.write(f"ERROR: {exc}")
                                                          ^
SyntaxError: invalid syntax
Warning: Error in : Error installing package(s): 'pip', 'wheel', 'setuptools'
     64: stop
     63: pip_install
     62: reticulate::virtualenv_create
     61: server [/srv/connect/apps/shiny-reticulate-app/server.R#18]
Error : Error installing package(s): 'pip', 'wheel', 'setuptools'
```

To fix, I added `pip` as a required dependency to ensure it gets installed into the virtualenv.
The app now deploys and runs again on shinyapps.io [here](https://elasticlabs.shinyapps.io/shiny-reticulate-app/)