### PR TITLE
Use `python` instead of `python3` on Windows

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -25,7 +25,15 @@ if (Sys.info()[['user']] == 'shiny'){
   
   # Running locally
   options(shiny.port = 7450)
-  Sys.setenv(PYTHON_PATH = 'python3')
+  if(Sys.info()[["sysname"]] == "Windows" & Sys.which("python") != "") {
+    Sys.setenv(PYTHON_PATH = 'python')
+  } else if(Sys.which("python3") != ""){
+    Sys.setenv(PYTHON_PATH = 'python3')
+  } else if(Sys.which("python") != ""){
+    Sys.setenv(PYTHON_PATH = 'python')
+  } else {
+    print("Neither `python3` or `python` is not in PATH. Make sure that you have Python installed.")
+  } 
   Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
   # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -26,6 +26,6 @@ if (Sys.info()[['user']] == 'shiny'){
   # Running locally
   options(shiny.port = 7450)
   Sys.setenv(PYTHON_PATH = 'python3')
-  Sys.setenv(VIRTUALENV_NAME = paste0("./", VIRTUALENV_NAME)) # exclude '/' => installs into ~/.virtualenvs/
+  Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
   # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/.Rprofile
+++ b/.Rprofile
@@ -26,6 +26,6 @@ if (Sys.info()[['user']] == 'shiny'){
   # Running locally
   options(shiny.port = 7450)
   Sys.setenv(PYTHON_PATH = 'python3')
-  Sys.setenv(VIRTUALENV_NAME = VIRTUALENV_NAME) # exclude '/' => installs into ~/.virtualenvs/
+  Sys.setenv(VIRTUALENV_NAME = paste0("./", VIRTUALENV_NAME)) # exclude '/' => installs into ~/.virtualenvs/
   # RETICULATE_PYTHON is not required locally, RStudio infers it based on the ~/.virtualenvs path
 }

--- a/server.R
+++ b/server.R
@@ -16,7 +16,7 @@ shinyServer(function(input, output) {
   
   # Create virtual env and install dependencies
   reticulate::virtualenv_create(envname = virtualenv_dir, python = python_path)
-  reticulate::virtualenv_install(virtualenv_dir, packages = PYTHON_DEPENDENCIES, ignore_installed=TRUE)
+  reticulate::virtualenv_install(virtualenv_dir, packages = PYTHON_DEPENDENCIES, ignore_installed=FALSE)
   reticulate::use_virtualenv(virtualenv_dir, required = T)
   
   # ------------------ App server logic (Edit anything below) --------------- #

--- a/server.R
+++ b/server.R
@@ -16,7 +16,7 @@ shinyServer(function(input, output) {
   
   # Create virtual env and install dependencies
   reticulate::virtualenv_create(envname = virtualenv_dir, python = python_path)
-  reticulate::virtualenv_install(virtualenv_dir, packages = PYTHON_DEPENDENCIES, ignore_installed=FALSE)
+  reticulate::virtualenv_install(virtualenv_dir, packages = PYTHON_DEPENDENCIES, ignore_installed=TRUE)
   reticulate::use_virtualenv(virtualenv_dir, required = T)
   
   # ------------------ App server logic (Edit anything below) --------------- #


### PR DESCRIPTION
This PR makes the app possible to run on Windows by pointing the path to python as `python` on Windows, instead of `python3`. This fixed #17 on my end. 